### PR TITLE
added case for organization not found

### DIFF
--- a/giggity.py
+++ b/giggity.py
@@ -19,10 +19,15 @@ class giggity():
         result = r.json()
         tree = {}
 
-        for account in result:
-            account["repos"]= self.getRepos(account["login"])
-            tree[account["login"]] = account
+        if(result["message"]=="Not Found"):
+            print("Organization Not Found")
+        
+        else: 
+            for account in result:
+                account["repos"]= self.getRepos(account["login"])
+                tree[account["login"]] = account
 
+            self.orgTree["users"] = tree
 
         self.orgTree["users"] = tree
         return tree


### PR DESCRIPTION
When an organization is not found, users get a "TypeError: string indices must be integers" error because account["login"] doesn't exist and it becomes a string instead of a dictionary. 